### PR TITLE
Update on master

### DIFF
--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -810,7 +810,12 @@ message MasterInfo {
 message SlaveInfo {
   required string hostname = 1;
   optional int32 port = 8 [default = 5051];
+
+  // The configured resources at the agent. This does not include any
+  // dynamic reservations or persistent volumes that may currently
+  // exist at the agent.
   repeated Resource resources = 3;
+
   repeated Attribute attributes = 5;
   optional SlaveID id = 6;
 

--- a/include/mesos/v1/mesos.proto
+++ b/include/mesos/v1/mesos.proto
@@ -810,7 +810,12 @@ message MasterInfo {
 message AgentInfo {
   required string hostname = 1;
   optional int32 port = 8 [default = 5051];
+
+  // The configured resources at the agent. This does not include any
+  // dynamic reservations or persistent volumes that may currently
+  // exist at the agent.
   repeated Resource resources = 3;
+
   repeated Attribute attributes = 5;
   optional AgentID id = 6;
 

--- a/src/cli/execute.cpp
+++ b/src/cli/execute.cpp
@@ -245,8 +245,8 @@ public:
     add(&Flags::framework_capabilities,
         "framework_capabilities",
         "Comma-separated list of optional framework capabilities to enable.\n"
-        "TASK_KILLING_STATE is always enabled. PARTITION_AWARE is enabled\n"
-        "unless --no-partition-aware is specified.");
+        "RESERVATION_REFINEMENT and TASK_KILLING_STATE are always enabled.\n"
+        "PARTITION_AWARE is enabled unless --no-partition-aware is specified.");
 
     add(&Flags::containerizer,
         "containerizer",
@@ -1035,7 +1035,8 @@ int main(int argc, char** argv)
     return EXIT_FAILURE;
   }
 
-  // Always enable the TASK_KILLING_STATE capability.
+  // Always enable the RESERVATION_REFINEMENT and TASK_KILLING_STATE
+  // capabilities.
   vector<FrameworkInfo::Capability::Type> frameworkCapabilities = {
     FrameworkInfo::Capability::RESERVATION_REFINEMENT,
     FrameworkInfo::Capability::TASK_KILLING_STATE,

--- a/src/master/master.cpp
+++ b/src/master/master.cpp
@@ -6389,6 +6389,14 @@ void Master::___reregisterSlave(
   message.mutable_resources()->CopyFrom(slave->checkpointedResources);
 
   if (!slave->capabilities.reservationRefinement) {
+    // If the agent is not refinement-capable, don't send it
+    // checkpointed resources that contain refined reservations. This
+    // might occur if a reservation refinement is created but never
+    // reaches the agent (e.g., due to network partition), and then
+    // the agent is downgraded before the partition heals.
+    //
+    // TODO(neilc): It would probably be better to prevent the agent
+    // from re-registering in this scenario.
     Try<Nothing> result = downgradeResources(message.mutable_resources());
     if (result.isError()) {
       LOG(WARNING) << "Not sending updated checkpointed resouces "
@@ -8870,6 +8878,14 @@ void Master::_apply(Slave* slave, const Offer::Operation& operation) {
   message.mutable_resources()->CopyFrom(slave->checkpointedResources);
 
   if (!slave->capabilities.reservationRefinement) {
+    // If the agent is not refinement-capable, don't send it
+    // checkpointed resources that contain refined reservations. This
+    // might occur if a reservation refinement is created but never
+    // reaches the agent (e.g., due to network partition), and then
+    // the agent is downgraded before the partition heals.
+    //
+    // TODO(neilc): It would probably be better to prevent the agent
+    // from re-registering in this scenario.
     Try<Nothing> result = downgradeResources(message.mutable_resources());
     if (result.isError()) {
       LOG(WARNING) << "Not sending updated checkpointed resouces "

--- a/src/master/master.hpp
+++ b/src/master/master.hpp
@@ -2890,22 +2890,14 @@ struct Role
 
     auto allocatedTo = [](const std::string& role) {
       return [role](const Resource& resource) {
+        CHECK(resource.has_allocation_info());
         return resource.allocation_info().role() == role;
       };
     };
 
     foreachvalue (Framework* framework, frameworks) {
-      // TODO(jay_guo): MULTI_ROLE is handled as a special case because
-      // the `Resource.allocation_info.role` is not yet populated. Once
-      // the support is complete, we do not need the `else` logic here.
-      if (protobuf::frameworkHasCapability(
-              framework->info, FrameworkInfo::Capability::MULTI_ROLE)) {
-        resources += framework->totalUsedResources.filter(allocatedTo(role));
-        resources += framework->totalOfferedResources.filter(allocatedTo(role));
-      } else {
-        resources += framework->totalUsedResources;
-        resources += framework->totalOfferedResources;
-      }
+      resources += framework->totalUsedResources.filter(allocatedTo(role));
+      resources += framework->totalOfferedResources.filter(allocatedTo(role));
     }
 
     return resources;

--- a/src/master/validation.cpp
+++ b/src/master/validation.cpp
@@ -318,9 +318,13 @@ Option<Error> reregisterSlave(
       return error.get();
     }
 
-    // We don't use internal::validateResources() here because
-    // that includes the validateAllocatedToSingleRole() check,
-    // which is not valid for agent re-registration.
+    // We don't use `internal::validateResources` here because that
+    // includes the `validateAllocatedToSingleRole` check, which is
+    // not valid for agent re-registration.
+    //
+    // TODO(neilc): Consider refactoring `internal::validateResources`
+    // to allow some but not all checks to be applied, or else inject
+    // allocation info into executor resources here.
     error = Resources::validate(executor.resources());
     if (error.isSome()) {
       return error.get();
@@ -367,7 +371,13 @@ Option<Error> reregisterSlave(
       }
     }
 
-    error = resource::validate(task.resources());
+    // We don't use `resource::validate` here because the task's
+    // resources might not be in "post-reservation refinement" format.
+    //
+    // TODO(neilc): Consider refactoring `resource::validate` to allow
+    // some but not all checks to be applied, or else convert the
+    // task's resources into post-refinement format here.
+    error = Resources::validate(task.resources());
     if (error.isSome()) {
       return Error("Task uses invalid resources: " + error->message);
     }

--- a/src/messages/messages.proto
+++ b/src/messages/messages.proto
@@ -429,11 +429,17 @@ message FrameworkErrorMessage {
  * Failure conditions are documented inline in Master::registerSlave.
  */
 message RegisterSlaveMessage {
+  // NOTE: The `Resources` in `SlaveInfo` cannot contain reservation
+  // refinements. Therefore, `slave.resources` will always use the
+  // "pre-reservation-refinement" format.
   required SlaveInfo slave = 1;
 
   // Resources that are checkpointed by the agent (e.g., persistent
   // volume or dynamic reservation). Frameworks need to release
-  // checkpointed resources explicitly.
+  // checkpointed resources explicitly. If any of the checkpointed
+  // resources use reservation refinements, every resource in this field
+  // will be represented using the "post-reservation-refinement" format;
+  // otherwise, this field will be in "pre-reservation-refinement" format.
   repeated Resource checkpointed_resources = 3;
 
   // NOTE: This is a hack for the master to detect the agent's
@@ -460,11 +466,17 @@ message RegisterSlaveMessage {
  * Failure conditions are documented inline in Master::reregisterSlave.
  */
 message ReregisterSlaveMessage {
+  // NOTE: The `Resources` in `SlaveInfo` cannot contain reservation
+  // refinements. Therefore, `slave.resources` will always use the
+  // "pre-reservation-refinement" format.
   required SlaveInfo slave = 2;
 
   // Resources that are checkpointed by the agent (e.g., persistent
   // volume or dynamic reservation). Frameworks need to release
-  // checkpointed resources explicitly.
+  // checkpointed resources explicitly. If any of the checkpointed
+  // resources use reservation refinements, every resource in this field
+  // will be represented using the "post-reservation-refinement" format;
+  // otherwise, this field will be in "pre-reservation-refinement" format.
   repeated Resource checkpointed_resources = 7;
 
   repeated ExecutorInfo executor_infos = 4;

--- a/src/slave/slave.cpp
+++ b/src/slave/slave.cpp
@@ -1393,11 +1393,11 @@ void Slave::doReliableRegistration(Duration maxBackoff)
 
   SlaveInfo slaveInfo = info;
 
-  // We ignore the `Try` from `downgradeResources` here because for now,
-  // we send the result either way.
-  // TODO(mpark): Do something smarter with the result once something like
-  // a master capability is introduced.
-  downgradeResources(slaveInfo.mutable_resources());
+  // The `SlaveInfo.resources` does not include dynamic reservations,
+  // which means it cannot contain reservation refinements, so
+  // `downgradeResources` should always succeed.
+  Try<Nothing> result = downgradeResources(slaveInfo.mutable_resources());
+  CHECK_SOME(result);
 
   RepeatedPtrField<Resource> checkpointedResources_ = checkpointedResources;
 

--- a/src/slave/slave.cpp
+++ b/src/slave/slave.cpp
@@ -1401,10 +1401,16 @@ void Slave::doReliableRegistration(Duration maxBackoff)
 
   RepeatedPtrField<Resource> checkpointedResources_ = checkpointedResources;
 
-  // We ignore the `Try` from `downgradeResources` here because for now,
-  // we send the result either way.
-  // TODO(mpark): Do something smarter with the result once something like
-  // a master capability is introduced.
+  // If the checkpointed resources don't have reservation refinements,
+  // send them to the master in "pre-reservation-refinement" format
+  // for backward compatibility with old masters. If downgrading is
+  // not possible without losing information, send the resources in
+  // the "post-reservation-refinement" format. We ignore the return
+  // value of `downgradeResources` because for now, we send the result
+  // either way.
+  //
+  // TODO(mpark): Do something smarter with the result once something
+  // like a master capability is introduced.
   downgradeResources(&checkpointedResources_);
 
   if (!slaveInfo.has_id()) {

--- a/src/tests/hierarchical_allocator_tests.cpp
+++ b/src/tests/hierarchical_allocator_tests.cpp
@@ -220,10 +220,11 @@ protected:
       }
     }
 
-    // Inject the MULTI_ROLE capability since the allocator never looks at
-    // whether the framework is MULTI_ROLE capable. The logic between a
-    // non-MULTI_ROLE scheduler and a single role MULTI_ROLE scheduler is
-    // the same as far as the allocator is concerned.
+    // Inject the MULTI_ROLE capability by default. The allocator ONLY looks
+    // at whether the framework is MULTI_ROLE capable to filter out offers
+    // from non-MULTI_ROLE agents (see MESOS-6940). Other than that, the logic
+    // between a non-MULTI_ROLE scheduler and a single role MULTI_ROLE scheduler
+    // is the same as far as the allocator is concerned.
     if (!multiRole) {
       frameworkInfo.add_capabilities()->set_type(
           FrameworkInfo::Capability::MULTI_ROLE);


### PR DESCRIPTION

 @neilconway	neilconway	Documented the content of the `SlaveInfo.resources` field.  …
Review: https://reviews.apache.org/r/60404
6b54349
 @neilconway	neilconway	Documented resource format in agent <-> master protocol.  …
Review: https://reviews.apache.org/r/60405
09fcc7f
 @neilconway	neilconway	Added comment to master logic for downgrading checkpointed resources.  …
Review: https://reviews.apache.org/r/60415
ea7c980
 @neilconway	neilconway	Added sanity check to resource downgrade on agent registration.  …
`SlaveInfo.resources` should always be representable in the
"pre-reservation-refinement" format, so `downgradeResources` should
always succeed.

Review: https://reviews.apache.org/r/60406
8bfb411
 @neilconway	neilconway	Avoided master crash on agent re-registration.  …
When validating the agent's ReregisterSlaveMessage, the master's
validation code neglected to account for the fact that the task
resources might not be in post-refinement format (e.g., if the agent
does not support reservation refinement). This lead to a `CHECK` failure
during validation.

Fix this by relaxing the validation of ReregisterSlaveMessage so that we
do not depend on the task resources being in post-refinement
format. This means validation of ReregisterSlaveMessage will be less
effective, but since it is best-effort anyway, this seems tolerable.

Review: https://reviews.apache.org/r/60407
46387fb
 @neilconway	neilconway	Avoided master crash on re-registration of old agents.  …
At present, agents that are refinement-capable send their task and
executor resources in the post-refinement format, whereas older agents
use the pre-refinement format. However, the master code only converted
agent resources to post-refinement format if the agent was not
multi-role capable. This leads to a subsequent `CHECK` failure for
agents that have multi-role but not reservation-refinement capabilities.

We should instead convert to post-refinement format for all
non-refinement capable agents.

Review: https://reviews.apache.org/r/60416
4ec8207
 @neilconway	neilconway	Updated comments and help text in mesos-execute.  …
Review: https://reviews.apache.org/r/60417
abe9d1b
Commits on Jun 26, 2017
 @guoger   @bmahler	guoger + bmahler	Removed temporary MULTI_ROLE implementation logic in the master.  …
After the completion of MULTI_ROLE support, allocation_info is always
populated, some redundant logic for resources of old format are not
necessary anymore, therefore removed.

Review: https://reviews.apache.org/r/58552/
44709a7
 @guoger   @bmahler	guoger + bmahler	Fixed an incorrect comment about MULTI_ROLE in the allocator tests.  …
Review: https://reviews.apache.org/r/58202/
18695ae
